### PR TITLE
Add missing types

### DIFF
--- a/src/Objects/ChatInviteLink.php
+++ b/src/Objects/ChatInviteLink.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Telegram\Bot\Objects;
+
+/**
+ * Class ChatInviteLink.
+ *
+ *
+ * @property string         $invite_link                The invite link. If the link was created by another chat administrator, then the second part of the link will be replaced with “…”.
+ * @property User           $creator                    Creator of the link.
+ * @property bool           $creates_join_request       True, if users joining the chat via the link need to be approved by chat administrators.
+ * @property bool           $is_primary                 True, if the link is primary.
+ * @property bool           $is_revoked                 True, if the link is revoked.
+ * @property string|null    $name                       Optional. Invite link name.
+ * @property int|null       $expire_date                Optional. Point in time (Unix timestamp) when the link will expire or has been expired.
+ * @property int|null       $member_limit               Optional. The maximum number of users that can be members of the chat simultaneously after joining the chat via this invite link; 1-99999.
+ * @property int|null       $pending_join_request_count Optional. Number of pending join requests created using this link.
+ */
+class ChatInviteLink extends BaseObject
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function relations()
+    {
+        return [
+            'creator' => User::class,
+        ];
+    }
+}

--- a/src/Objects/ChatJoinRequest.php
+++ b/src/Objects/ChatJoinRequest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Telegram\Bot\Objects;
+
+/**
+ * Class ChatJoinRequest.
+ *
+ *
+ * @property Chat                   $chat           Chat to which the request was sent.
+ * @property User                   $from           User that sent the join request.
+ * @property int                    $date           Date the request was sent in Unix time.
+ * @property string|null            $bio            Optional. Bio of the user.
+ * @property ChatInviteLink|null    $invite_link    Optional. Chat invite link that was used by the user to send the join request.
+ */
+class ChatJoinRequest extends BaseObject
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function relations()
+    {
+        return [
+            'chat' => Chat::class,
+            'from' => User::class,
+            'invite_link' => ChatInviteLink::class,
+        ];
+    }
+}

--- a/src/Objects/ChatMemberUpdated.php
+++ b/src/Objects/ChatMemberUpdated.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Telegram\Bot\Objects;
+
+/**
+ * Class ChatMemberUpdated.
+ *
+ *
+ * @property Chat                   $chat               Chat the user belongs to.
+ * @property User                   $from               Performer of the action, which resulted in the change.
+ * @property int                    $date               Date the change was done in Unix time.
+ * @property ChatMember             $old_chat_member    Previous information about the chat member.
+ * @property ChatMember             $new_chat_member    Previous information about the chat member.
+ * @property ChatInviteLink|null    $invite_link        Optional. Chat invite link, which was used by the user to join the chat; for joining by invite link events only.
+ */
+class ChatMemberUpdated extends BaseObject
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function relations()
+    {
+        return [
+            'chat' => Chat::class,
+            'from' => User::class,
+            'old_chat_member' => ChatMember::class,
+            'new_chat_member' => ChatMember::class,
+            'invite_link' => ChatInviteLink::class,
+        ];
+    }
+}

--- a/src/Objects/PollAnswer.php
+++ b/src/Objects/PollAnswer.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Telegram\Bot\Objects;
+
+/**
+ * Class PollAnswer.
+ *
+ *
+ * @property string       $poll_id      Unique poll identifier.
+ * @property User         $user         The user, who changed the answer to the poll.
+ * @property array        $option_ids   0-based identifiers of answer options, chosen by the user. May be empty if the user retracted their vote.
+ */
+class PollAnswer extends BaseObject
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function relations()
+    {
+        return [
+            'user' => User::class,
+        ];
+    }
+}

--- a/src/Objects/Update.php
+++ b/src/Objects/Update.php
@@ -97,6 +97,10 @@ class Update extends BaseObject
             'shipping_query',
             'pre_checkout_query',
             'poll',
+            'poll_answer',
+            'my_chat_member',
+            'chat_member',
+            'chat_join_request',
         ];
 
         return $this->keys()


### PR DESCRIPTION
Add missing types:

 * ChatInviteLink
 * ChatJoinRequest
 * ChatMemberUpdated
 * PollAnswer


It changes `Update::detectType()` output, that means this is BC changes, but there is nothing to do with it due to bad package architecture.